### PR TITLE
'install' section added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ convenient and suitable for production environment.
 + libelf, on GNU/Linux, while FreeBSD has libelf already.
 
 
+## install
+
+### debian
+
+	sudo apt-get install libunwind-dev libelf-dev libdwarf-dev
+	./configure
+	make && sudo make install
+
+
 ## usage
 
 To detect a running process:


### PR DESCRIPTION
Step-by-step instructions to install memleax. Use the Debian package names of the requirements. Only tested under Debian 8.2.